### PR TITLE
Fix of TypeError

### DIFF
--- a/lib/stratum/merkleTree.js
+++ b/lib/stratum/merkleTree.js
@@ -5,7 +5,7 @@ var util = require('./util.js');
 
 function calcRoot(hashes) {
     var result = merklebitcoin(hashes);
-    return result._65.root;
+    return Object.values(result)[2].root;
 }
 
 exports.getRoot = function (rpcData, generateTxRaw) {


### PR DESCRIPTION
TypeError: Cannot read property 'root' of undefined
Crash on return result._65.root in merkleTree.js